### PR TITLE
Fix bold parsing and support combined inline formatting

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
         body: const Center(
           child: WhatsAppTextFormatter(
             text: """
-**Bold**  
+*Bold*  
 _Italic_  
 ~~Strikethrough~~  
 ```Monospace```  

--- a/lib/whatsapp_text_formatter.dart
+++ b/lib/whatsapp_text_formatter.dart
@@ -10,7 +10,7 @@ class WhatsAppTextFormatter extends StatelessWidget {
   ///
   /// This widget supports:
   /// - *Italic* (`_text_`)
-  /// - **Bold** (`**text**`)
+  /// - *Bold* (`*text*`)
   /// - ~~Strikethrough~~ (`~~text~~`)
   /// - `Monospace` (`` `text` ``)
   /// - Bulleted List (`* text` or `- text`)
@@ -26,11 +26,7 @@ class WhatsAppTextFormatter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    TextStyle defaultStyle =
-        (style ?? DefaultTextStyle.of(context).style).copyWith(
-      color: style?.color ??
-          Colors.black, // Default to black if no color is provided
-    );
+    final defaultStyle = (style ?? DefaultTextStyle.of(context).style);
 
     return RichText(
       textAlign: textAlign,
@@ -42,93 +38,179 @@ class WhatsAppTextFormatter extends StatelessWidget {
   }
 
   List<TextSpan> _parseWhatsAppFormat(String text, TextStyle defaultStyle) {
-    final RegExp exp = RegExp(
-      r"(\*\*(.*?)\*\*|_(.*?)_|~~(.*?)~~|```(.*?)```|`(.*?)`|^(\*|\-) (.*?)$|^(\d+)\. (.*?)$|^> (.*?)$)",
-      multiLine: true,
-    );
+    final spans = <TextSpan>[];
+    final lines = text.split('\n');
 
-    List<TextSpan> spans = [];
-    int lastMatchEnd = 0;
+    for (var i = 0; i < lines.length; i++) {
+      final line = lines[i];
 
-    for (var match in exp.allMatches(text)) {
-      if (match.start > lastMatchEnd) {
-        spans.add(TextSpan(
-            text: text.substring(lastMatchEnd, match.start),
-            style: defaultStyle));
-      }
+      final bulletMatch = RegExp(r'^\s*([\*\-]) (.+)$').firstMatch(line);
+      final numMatch = RegExp(r'^\s*(\d+)\. (.+)$').firstMatch(line);
+      final quoteMatch = RegExp(r'^\s*>\s?(.*)$').firstMatch(line);
 
-      String? bold = match.group(2);
-      String? italic = match.group(3);
-      String? strikethrough = match.group(4);
-      String? monospaceBlock = match.group(5);
-      String? inlineCode = match.group(6);
-      String? bulletSymbol = match.group(7);
-      String? bulletText = match.group(8);
-      String? numberedIndex = match.group(9);
-      String? numberedText = match.group(10);
-      String? quoteText = match.group(11);
+      final baseStyle = defaultStyle;
+      var innerText = line;
 
-      if (bold != null) {
+      if (bulletMatch != null) {
+        innerText = bulletMatch.group(2)!;
         spans.add(TextSpan(
-          text: bold,
-          style:
-              defaultStyle.merge(const TextStyle(fontWeight: FontWeight.bold)),
-        ));
-      } else if (italic != null) {
+            text: '${i > 0 ? '\n' : ''}• ',
+            style:
+                baseStyle.merge(const TextStyle(fontWeight: FontWeight.bold))));
+        spans.addAll(_parseInlineStyles(innerText,
+            baseStyle.merge(const TextStyle(fontWeight: FontWeight.bold))));
+      } else if (numMatch != null) {
+        innerText = numMatch.group(2)!;
+        String numberStr = numMatch.group(1)!;
         spans.add(TextSpan(
-          text: italic,
-          style:
-              defaultStyle.merge(const TextStyle(fontStyle: FontStyle.italic)),
-        ));
-      } else if (strikethrough != null) {
+            text: '${i > 0 ? '\n' : ''}$numberStr. ',
+            style:
+                baseStyle.merge(const TextStyle(fontWeight: FontWeight.bold))));
+        spans.addAll(_parseInlineStyles(innerText,
+            baseStyle.merge(const TextStyle(fontWeight: FontWeight.bold))));
+      } else if (quoteMatch != null) {
+        innerText = quoteMatch.group(1)!;
         spans.add(TextSpan(
-          text: strikethrough,
-          style: defaultStyle
-              .merge(const TextStyle(decoration: TextDecoration.lineThrough)),
-        ));
-      } else if (monospaceBlock != null) {
-        spans.add(TextSpan(
-          text: monospaceBlock,
-          style: defaultStyle.merge(const TextStyle(fontFamily: 'monospace')),
-        ));
-      } else if (inlineCode != null) {
-        spans.add(TextSpan(
-          text: inlineCode,
-          style: defaultStyle.merge(const TextStyle(
-            fontFamily: 'monospace',
-            backgroundColor: Colors.grey,
-          )),
-        ));
-      } else if (bulletSymbol != null && bulletText != null) {
-        spans.add(TextSpan(
-          text: '\n• $bulletText',
-          style:
-              defaultStyle.merge(const TextStyle(fontWeight: FontWeight.bold)),
-        ));
-      } else if (numberedIndex != null && numberedText != null) {
-        spans.add(TextSpan(
-          text: '\n$numberedIndex. $numberedText',
-          style:
-              defaultStyle.merge(const TextStyle(fontWeight: FontWeight.bold)),
-        ));
-      } else if (quoteText != null) {
-        spans.add(TextSpan(
-          text: '\n> $quoteText',
-          style: defaultStyle.merge(const TextStyle(
+          text: '${i > 0 ? '\n' : ''}> ',
+          style: baseStyle.merge(const TextStyle(
             fontStyle: FontStyle.italic,
             color: Colors.grey,
           )),
         ));
+        spans.addAll(_parseInlineStyles(
+            innerText,
+            baseStyle.merge(const TextStyle(
+              fontStyle: FontStyle.italic,
+              color: Colors.grey,
+            ))));
+      } else {
+        if (i != 0) {
+          spans.add(const TextSpan(text: '\n'));
+        }
+        spans.addAll(_parseInlineStyles(innerText, baseStyle));
+      }
+    }
+
+    return spans;
+  }
+
+  List<TextSpan> _parseInlineStyles(String text, TextStyle baseStyle) {
+    final codeBlockExp = RegExp(r'```(.*?)```', dotAll: true);
+    final firstCodeBlockMatch = codeBlockExp.firstMatch(text);
+
+    if (firstCodeBlockMatch != null) {
+      final spans = <TextSpan>[];
+
+      if (firstCodeBlockMatch.start > 0) {
+        spans.addAll(_parseInlineStyles(
+          text.substring(0, firstCodeBlockMatch.start),
+          baseStyle,
+        ));
       }
 
+      spans.add(TextSpan(
+        text: firstCodeBlockMatch.group(1),
+        style: baseStyle.merge(const TextStyle(fontFamily: 'monospace')),
+      ));
+
+      if (firstCodeBlockMatch.end < text.length) {
+        spans.addAll(_parseInlineStyles(
+          text.substring(firstCodeBlockMatch.end),
+          baseStyle,
+        ));
+      }
+
+      return spans;
+    }
+
+    final inlineCodeExp = RegExp(r'`([^`\n]+?)`');
+    final matches = inlineCodeExp.allMatches(text).toList();
+
+    if (matches.isNotEmpty) {
+      List<TextSpan> spans = [];
+      int lastMatchEnd = 0;
+      for (final match in matches) {
+        if (match.start > lastMatchEnd) {
+          spans.addAll(_parseBoldItalicStrike(
+              text.substring(lastMatchEnd, match.start), baseStyle));
+        }
+        spans.add(TextSpan(
+          text: match.group(1),
+          style: baseStyle.merge(const TextStyle(
+            fontFamily: 'monospace',
+            backgroundColor: Colors.grey,
+          )),
+        ));
+        lastMatchEnd = match.end;
+      }
+      if (lastMatchEnd < text.length) {
+        spans.addAll(
+            _parseBoldItalicStrike(text.substring(lastMatchEnd), baseStyle));
+      }
+      return spans;
+    }
+
+    return _parseBoldItalicStrike(text, baseStyle);
+  }
+
+  List<TextSpan> _parseBoldItalicStrike(String text, TextStyle baseStyle) {
+    final spans = <TextSpan>[];
+    final pattern = RegExp(
+      r'(~~(?<strike>.+?)~~)|(\*(?! )(?!\*)(?<bold>(?:[^\*]|(\*[^\*]))+?)\*)|(_(?<italic>[^_]+?)_)',
+    );
+
+    int lastMatchEnd = 0;
+    final matches = pattern.allMatches(text).toList();
+
+    for (final match in matches) {
+      if (match.start > lastMatchEnd) {
+        spans.add(TextSpan(
+          text: text.substring(lastMatchEnd, match.start),
+          style: baseStyle,
+        ));
+      }
+      final strike = match.namedGroup('strike');
+      final bold = match.namedGroup('bold');
+      final italic = match.namedGroup('italic');
+
+      if (strike != null) {
+        spans.add(
+          TextSpan(
+            children: _parseBoldItalicStrike(
+                strike,
+                baseStyle.merge(
+                    const TextStyle(decoration: TextDecoration.lineThrough))),
+            style: baseStyle
+                .merge(const TextStyle(decoration: TextDecoration.lineThrough)),
+          ),
+        );
+      } else if (bold != null) {
+        spans.add(
+          TextSpan(
+            children: _parseBoldItalicStrike(bold,
+                baseStyle.merge(const TextStyle(fontWeight: FontWeight.bold))),
+            style:
+                baseStyle.merge(const TextStyle(fontWeight: FontWeight.bold)),
+          ),
+        );
+      } else if (italic != null) {
+        spans.add(
+          TextSpan(
+            children: _parseBoldItalicStrike(italic,
+                baseStyle.merge(const TextStyle(fontStyle: FontStyle.italic))),
+            style:
+                baseStyle.merge(const TextStyle(fontStyle: FontStyle.italic)),
+          ),
+        );
+      }
       lastMatchEnd = match.end;
     }
-
     if (lastMatchEnd < text.length) {
-      spans.add(
-          TextSpan(text: text.substring(lastMatchEnd), style: defaultStyle));
+      spans.add(TextSpan(
+        text: text.substring(lastMatchEnd),
+        style: baseStyle,
+      ));
     }
-
     return spans;
   }
 }

--- a/test/whatsapp_text_formatter_test.dart
+++ b/test/whatsapp_text_formatter_test.dart
@@ -3,38 +3,174 @@ import 'package:flutter/material.dart';
 import 'package:whatsapp_text_formatter/whatsapp_text_formatter.dart';
 
 void main() {
-  testWidgets('WhatsAppTextFormatter formats bold text correctly',
-      (WidgetTester tester) async {
-    // Define a test key for the widget
-    const testKey = Key('formatted_text');
+  const testKey = Key('formatted_text');
 
-    // Test text with WhatsApp-style formatting
-    const testText = """
-**Bold**  
-_Italic_  
-~~Strikethrough~~  
-```Monospace```  
-`Inline Code`  
-* Bullet Point  
-- Another Bullet Point
-1. Numbered List  
-> Quoted Text  
-""";
-
-    // Build the widget
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: WhatsAppTextFormatter(
-            key: testKey,
-            text: testText,
-          ),
+  Widget buildWidget(String text) {
+    return MaterialApp(
+      home: Scaffold(
+        body: WhatsAppTextFormatter(
+          key: testKey,
+          text: text,
         ),
       ),
     );
+  }
 
-    // Find the formatted text widget
-    final textFinder = find.byKey(testKey);
-    expect(textFinder, findsOneWidget);
+  testWidgets('WhatsAppTextFormatter renders bold text', (WidgetTester tester) async {
+    const input = '*Bold*';
+    await tester.pumpWidget(buildWidget(input));
+    final richText = tester.widget<RichText>(find.descendant(of: find.byKey(testKey), matching: find.byType(RichText)));
+    final span = richText.text as TextSpan;
+
+    bool foundBold = false;
+    void searchBold(TextSpan span) {
+      if (span.style?.fontWeight == FontWeight.bold && span.toPlainText() == 'Bold') {
+        foundBold = true;
+      }
+      if (span.children != null) {
+        for (final child in span.children!) {
+          if (child is TextSpan) searchBold(child);
+        }
+      }
+    }
+    searchBold(span);
+
+    expect(foundBold, isTrue);
+  });
+
+  testWidgets('WhatsAppTextFormatter renders italic text', (WidgetTester tester) async {
+    const input = '_Italic_';
+    await tester.pumpWidget(buildWidget(input));
+    final richText = tester.widget<RichText>(find.descendant(of: find.byKey(testKey), matching: find.byType(RichText)));
+    final span = richText.text as TextSpan;
+
+    bool foundItalic = false;
+    void searchItalic(TextSpan span) {
+      if (span.style?.fontStyle == FontStyle.italic && span.toPlainText() == 'Italic') {
+        foundItalic = true;
+      }
+      if (span.children != null) {
+        for (final child in span.children!) {
+          if (child is TextSpan) searchItalic(child);
+        }
+      }
+    }
+    searchItalic(span);
+
+    expect(foundItalic, isTrue);
+  });
+
+  testWidgets('WhatsAppTextFormatter renders strikethrough', (WidgetTester tester) async {
+    const input = '~~Strike~~';
+    await tester.pumpWidget(buildWidget(input));
+    final richText = tester.widget<RichText>(find.descendant(of: find.byKey(testKey), matching: find.byType(RichText)));
+    final span = richText.text as TextSpan;
+
+    bool foundStrike = false;
+    void searchStrike(TextSpan span) {
+      final style = span.style;
+      if (style != null &&
+          style.decoration != null &&
+          style.decoration!.contains(TextDecoration.lineThrough) &&
+          span.toPlainText() == 'Strike') {
+        foundStrike = true;
+      }
+      if (span.children != null) {
+        for (final child in span.children!) {
+          if (child is TextSpan) searchStrike(child);
+        }
+      }
+    }
+    searchStrike(span);
+
+    expect(foundStrike, isTrue);
+  });
+
+  testWidgets('WhatsAppTextFormatter renders monospace code block', (WidgetTester tester) async {
+    const input = '```Monospace```';
+    await tester.pumpWidget(buildWidget(input));
+    final richText = tester.widget<RichText>(find.descendant(of: find.byKey(testKey), matching: find.byType(RichText)));
+    final span = richText.text as TextSpan;
+    bool foundMonospace = false;
+    void searchMonospace(TextSpan span) {
+      if ((span.style?.fontFamily == 'monospace') && span.toPlainText() == 'Monospace') {
+        foundMonospace = true;
+      }
+      if (span.children != null) {
+        for (final child in span.children!) {
+          if (child is TextSpan) searchMonospace(child);
+        }
+      }
+    }
+    searchMonospace(span);
+
+    expect(foundMonospace, isTrue);
+  });
+
+  testWidgets('WhatsAppTextFormatter renders inline code', (WidgetTester tester) async {
+    const input = '`Inline Code`';
+    await tester.pumpWidget(buildWidget(input));
+    final richText = tester.widget<RichText>(find.descendant(of: find.byKey(testKey), matching: find.byType(RichText)));
+    final span = richText.text as TextSpan;
+    bool foundInlineCode = false;
+    void searchInlineCode(TextSpan span) {
+      final style = span.style;
+      if (style != null &&
+          style.fontFamily == 'monospace' &&
+          style.backgroundColor == Colors.grey &&
+          span.toPlainText() == 'Inline Code') {
+        foundInlineCode = true;
+      }
+      if (span.children != null) {
+        for (final child in span.children!) {
+          if (child is TextSpan) searchInlineCode(child);
+        }
+      }
+    }
+    searchInlineCode(span);
+
+    expect(foundInlineCode, isTrue);
+  });
+
+  testWidgets('WhatsAppTextFormatter renders bullet list', (WidgetTester tester) async {
+    const input = '* Bullet Point\n- Second Point';
+    await tester.pumpWidget(buildWidget(input));
+    final richText = tester.widget<RichText>(find.descendant(of: find.byKey(testKey), matching: find.byType(RichText)));
+    final span = richText.text as TextSpan;
+    final plain = span.toPlainText();
+    expect(plain, contains('• Bullet Point'));
+    expect(plain, contains('• Second Point'));
+  });
+
+  testWidgets('WhatsAppTextFormatter renders numbered list', (WidgetTester tester) async {
+    const input = '1. First Item\n2. Second Item';
+    await tester.pumpWidget(buildWidget(input));
+    final richText = tester.widget<RichText>(find.descendant(of: find.byKey(testKey), matching: find.byType(RichText)));
+    final span = richText.text as TextSpan;
+    final plain = span.toPlainText();
+    expect(plain, contains('1. First Item'));
+    expect(plain, contains('2. Second Item'));
+  });
+
+  testWidgets('WhatsAppTextFormatter renders quote', (WidgetTester tester) async {
+    const input = '> Quoted Text';
+    await tester.pumpWidget(buildWidget(input));
+    final richText = tester.widget<RichText>(find.descendant(of: find.byKey(testKey), matching: find.byType(RichText)));
+    final span = richText.text as TextSpan;
+    final plain = span.toPlainText();
+    expect(plain, contains('> Quoted Text'));
+  });
+
+  testWidgets('WhatsAppTextFormatter renders mixed formatting', (WidgetTester tester) async {
+    const input = '*Bold* _Italic_ ~~Strike~~ `inline` ```block```';
+    await tester.pumpWidget(buildWidget(input));
+    final richText = tester.widget<RichText>(find.descendant(of: find.byKey(testKey), matching: find.byType(RichText)));
+    final span = richText.text as TextSpan;
+    final plain = span.toPlainText();
+    expect(plain, contains('Bold'));
+    expect(plain, contains('Italic'));
+    expect(plain, contains('Strike'));
+    expect(plain, contains('inline'));
+    expect(plain, contains('block'));
   });
 }


### PR DESCRIPTION
### Problem

- Bold formatting was incorrect (**text**) and did not follow the WhatsApp standard (*text*).
- Inline formatting did not support multiple styles on the same text segment (e.g. bold + italic).

### Solution
- Updated bold syntax to use *text*.
- Refactored the parser to separate:
- line-level parsing (lists, quotes)
- inline parsing (code, bold, italic, strike)
- Inline parsing is now recursive, allowing nested and combined styles.
- Removed forced default text color to respect inherited styles.

### Tests
- Added widget tests covering:
- bold, italic, strikethrough
- inline code and code blocks
- lists and quotes
- mixed formatting

### Note
- Breaking change: **text** is no longer recognized as bold (aligned with WhatsApp formatting).